### PR TITLE
Fixed acceptor exclusions.

### DIFF
--- a/VaSeBuilder.py
+++ b/VaSeBuilder.py
@@ -626,7 +626,7 @@ class VaSeBuilder:
 
                 # Check if we are located at a read identifier.
                 if fileline.startswith(b"@"):
-                    if fileline.decode("utf-8").strip()[1:] not in acceptorreads_toskip:
+                    if fileline.decode("utf-8").split()[0][1:] not in acceptorreads_toskip:
                         fqgz_outfile.write(fileline)
                         fqgz_outfile.write(next(fqgz_infile))
                         fqgz_outfile.write(next(fqgz_infile))


### PR DESCRIPTION
Acceptor reads were not being properly filtered. Each readID line in the fastq files was being compared against a list of readIDs to be excluded. However, the whole line was being compared to the exclusion readIDs, and each line also has an additional annotation after the readID. Fixed this by splitting the identifier line on white space and only comparing the ID. 