### PR TITLE
Fix missing FastQ mates and hardclipped reads.

### DIFF
--- a/VaSeBuilder.py
+++ b/VaSeBuilder.py
@@ -1860,7 +1860,7 @@ class VaSeBuilder:
                                                        variantpos, acontext, dcontext, abamfile, dbamfile, write_unm)
         self.debug_msg("cc", variantid, t0)
         self.vaselogger.debug(f"Combined context determined to be {vcontext.get_variant_context_chrom()}:"
-                              f"{vcontext.get_variant_context_start()}:{vcontext.get_variant_context_end()}")
+                              f"{vcontext.get_variant_context_start()}-{vcontext.get_variant_context_end()}")
         return vcontext
 
     # Establishes a variant context from an acceptor and donor context and fetches acceptor and donor reads again.


### PR DESCRIPTION
Hardclipping fix:
1) Any fetched read that is hardclipped (noted in the cigar string) is appended to a separate list.
2) After fetching is complete, the hardclipped reads' SA tag is read to identify the location of their primary alignments (hardclipped reads are never primary reads).
3) A fetch is performed at the location, and the results are filtered to find the correct primary alignment.
    - Similar to method for fetching mates.
4) The primary alignment is added to the rest of the fetched reads.

Altered mate fetching:
1) Fetched reads are split into read1 and read2 lists.
2) Any read in the read1 list that does not have a mate in the read2 list has its mate fetched
    - Uses the same mate fetching method as before, but performed per appropriate read instead of for the full list of reads.
    - Important additional criteria: Matching mate must have the opposite pair number. This was missing before, resulting in some reads fetching themselves instead of their unmapped mate, which would cause a copy to be lost during uniquifying.
3) Vice-versa for read2's.
4) Read1 and read2 lists are combined, then converted into DonorBamRead objects as before.

Small cleanup/fixes to debug messages.
